### PR TITLE
feat: support chained emojis

### DIFF
--- a/lib/src/regex.dart
+++ b/lib/src/regex.dart
@@ -10,5 +10,4 @@ abstract class Regex {
 
   /// A regular expression for matching emoji shortcodes.
   static final shortcode = RegExp(r':[^:\s]+:(?::skin-tone-[2-6]:)?');
-  // static final shortcode = RegExp(r':[^:\s]*(?:::[^:\s]*)*:');
 }

--- a/lib/src/regex.dart
+++ b/lib/src/regex.dart
@@ -9,5 +9,6 @@ abstract class Regex {
       unicode: true);
 
   /// A regular expression for matching emoji shortcodes.
-  static final shortcode = RegExp(r':[^:\s]*(?:::[^:\s]*)*:');
+  static final shortcode = RegExp(r':[^:\s]+:(?::skin-tone-[2-6]:)?');
+  // static final shortcode = RegExp(r':[^:\s]*(?:::[^:\s]*)*:');
 }

--- a/test/src/emojis/emoji_parser_test.dart
+++ b/test/src/emojis/emoji_parser_test.dart
@@ -237,6 +237,24 @@ void main() {
       expect(value, expected);
     });
 
+    test(
+        'fromShortcodes() returns correct text with emoji in place of shortcode when emojis are chained (without skin tone)',
+        () {
+      const text = ':otter::woman-facepalming::santa::dancer::female-astronaut:';
+      final value = EmojiParser(text).fromShortcodes();
+      const expected = '🦦🤦‍♀️🎅💃👩‍🚀';
+      expect(value, expected);
+    });
+
+    test(
+        'fromShortcodes() returns correct text with emoji in place of shortcode when emojis are chained',
+        () {
+      const text = ':otter::woman-facepalming::skin-tone-5::santa::dancer::skin-tone-4::female-astronaut::skin-tone-5:';
+      final value = EmojiParser(text).fromShortcodes();
+      const expected = '🦦🤦🏾‍♀️🎅💃🏽👩🏾‍🚀';
+      expect(value, expected);
+    });
+
     test('get returns list of emojis from given text', () {
       const text = 'text😀text🤦🏾‍♀️text';
       final value = EmojiParser(text).get;

--- a/test/src/emojis/emoji_parser_test.dart
+++ b/test/src/emojis/emoji_parser_test.dart
@@ -240,7 +240,8 @@ void main() {
     test(
         'fromShortcodes() returns correct text with emoji in place of shortcode when emojis are chained (without skin tone)',
         () {
-      const text = ':otter::woman-facepalming::santa::dancer::female-astronaut:';
+      const text =
+          ':otter::woman-facepalming::santa::dancer::female-astronaut:';
       final value = EmojiParser(text).fromShortcodes();
       const expected = '🦦🤦‍♀️🎅💃👩‍🚀';
       expect(value, expected);
@@ -249,7 +250,8 @@ void main() {
     test(
         'fromShortcodes() returns correct text with emoji in place of shortcode when emojis are chained',
         () {
-      const text = ':otter::woman-facepalming::skin-tone-5::santa::dancer::skin-tone-4::female-astronaut::skin-tone-5:';
+      const text =
+          ':otter::woman-facepalming::skin-tone-5::santa::dancer::skin-tone-4::female-astronaut::skin-tone-5:';
       final value = EmojiParser(text).fromShortcodes();
       const expected = '🦦🤦🏾‍♀️🎅💃🏽👩🏾‍🚀';
       expect(value, expected);


### PR DESCRIPTION
In the current state, "🦦🤦‍♀️🎅💃👩‍🚀" is matched as a single long shortcode ":otter::woman-facepalming::santa::dancer::female-astronaut:"

This PR allow to correctly split the emojis