### PR TITLE
fix: remove invalid use of package:collection

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   emoji_extension:
     dependency: "direct main"
     description:
@@ -17,4 +17,4 @@ packages:
     source: path
     version: "1.1.1"
 sdks:
-  dart: ">=2.19.6 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"

--- a/lib/emoji_extension.dart
+++ b/lib/emoji_extension.dart
@@ -2,8 +2,6 @@ library emoji_extension;
 
 import 'package:emoji_extension/src/emojis/emoji_parser/emoji_parser.dart';
 
-export 'package:collection/collection.dart';
-
 export 'src/emojis/color.dart';
 export 'src/emojis/emoji_parser/emoji_parser.dart';
 export 'src/emojis/emojis.dart';

--- a/lib/src/emojis/emoji_parser/emoji_parser.dart
+++ b/lib/src/emojis/emoji_parser/emoji_parser.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:emoji_extension/emoji_extension.dart';
 import 'package:emoji_extension/src/extensions/string_extensions.dart';
 import 'package:emoji_extension/src/regex.dart';

--- a/lib/src/emojis/emoji_parser/emoji_parser_getters.dart
+++ b/lib/src/emojis/emoji_parser/emoji_parser_getters.dart
@@ -299,12 +299,15 @@ extension EmojiParserGetters on EmojiParser {
   /// ```
   String get shuffle {
     String output = _value;
+    final extract = this.extract;
     extract.forEachIndexed((i, e) {
       output = output.replaceFirst(e, '[$i]');
     });
-    extract.shuffled.forEachIndexed((i, e) {
-      output = output.replaceFirst('[$i]', e);
-    });
+    extract
+      ..shuffle()
+      ..forEachIndexed((i, e) {
+        output = output.replaceFirst('[$i]', e);
+      });
 
     return output;
   }

--- a/lib/src/emojis/emojis.dart
+++ b/lib/src/emojis/emojis.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:emoji_extension/emoji_extension.dart';
 import 'package:emoji_extension/src/extensions/string_extensions.dart';
 import 'package:emoji_extension/src/regex.dart';

--- a/lib/src/extensions/shortcode_iterable_extensions.dart
+++ b/lib/src/extensions/shortcode_iterable_extensions.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:emoji_extension/emoji_extension.dart';
 import 'package:emoji_extension/src/extensions/string_extensions.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,14 +6,14 @@ issue_tracker: https://github.com/Nikoro/emoji_extension/issues
 topics: [emoji, emojis, collection, unicode]
 
 environment:
-  sdk: '>=2.18.6 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   collection: ^1.18.0
 
 dev_dependencies:
   test: ^1.25.4
-  flutter_lints: ^3.0.2
+  flutter_lints: ^5.0.0
 
 screenshots:
   - description: The emoji extension logo

--- a/test/src/emojis/emoji_parser/emoji_parser_getters_test.dart
+++ b/test/src/emojis/emoji_parser/emoji_parser_getters_test.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:emoji_extension/emoji_extension.dart';
 import 'package:test/test.dart';
 

--- a/test/src/extensions/iterable_extensions_test.dart
+++ b/test/src/extensions/iterable_extensions_test.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart' hide IterableExtension;
 import 'package:emoji_extension/emoji_extension.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
- Removes unintended export of `package:collection`
- Fixes the invalid Dart SDK compatibility expression
- Make `shuffled()` Dart 3.6.0 compatible

Fixes: #13